### PR TITLE
Bit check macro changed to boolean type

### DIFF
--- a/tca9555_driver.c
+++ b/tca9555_driver.c
@@ -50,7 +50,7 @@
 #define BIT_SET(reg,nbit)                   (reg) |=  (1<<(nbit))
 #define BIT_CLR(reg,nbit)                   (reg) &= ~(1<<(nbit))
 #define BIT_TGL(reg,nbit)                   (reg) ^=  (1<<(nbit))
-#define BIT_CHECK(reg,nbit)                 ((reg) &  (1<<(nbit)))
+#define BIT_CHECK(reg,nbit)                 (((reg) & (1 << (nbit))) >> (nbit))
 
 /*****************************************************************************/
 


### PR DESCRIPTION
Bit check macro works correctly only when checking zero bit. 
For example, see  `if` statement in tca9555_driver.c at line 346:
```c
    if(BIT_CHECK(output_register, pin) != state) {
        BIT_TGL(output_register, pin);
        rslt = tca9555_write_reg(device, TCA9555_REG_ADDR_OUTPUT, &output_register);
    }
```
`BIT_CHECK` will return 2, 4, 8... if bit 1, 2, 3... is set. `state` variable can only be `0` or `1`. Condition will be true even if corresponding bin is set and `state` is 1.
Tested this fix on my hardware and everything worked fine. 